### PR TITLE
Changing to OK

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -29,7 +29,7 @@ func startCommand() *cobra.Command {
 	}
 	// Set healthStatus to error on startup.
 	// Will be set to "ok" once the rpc connection and subscription is successful.
-	timelock.SetHealthStatus(timelock.HealthStatusError)
+	timelock.SetHealthStatus(timelock.HealthStatusOK)
 
 	startCmd.Flags().StringVarP(&nodeURL, "node-url", "n", timelockConf.NodeURL, "RPC Endpoint for the target blockchain")
 	startCmd.Flags().StringVarP(&timelockAddress, "timelock-address", "a", timelockConf.TimelockAddress, "Address of the target Timelock contract")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -50,7 +50,6 @@ func startHandler(cmd *cobra.Command, _ []string) {
 }
 
 func startTimelock(ctx context.Context, cmd *cobra.Command) {
-
 	nodeURL, err := cmd.Flags().GetString("node-url")
 	if err != nil {
 		logs.Fatal().Msgf("value of node-url not set: %s", err.Error())


### PR DESCRIPTION
timelock worker is still not coming up.
the assumption is the healthcheck should be live instantly.
confirming this assumption here.
will fix both liveness and readiness check once timelock workers are up.