### PR TITLE
scheduler: sorts the store records before writing them

### DIFF
--- a/pkg/timelock/scheduler.go
+++ b/pkg/timelock/scheduler.go
@@ -161,6 +161,12 @@ func (tw *Worker) dumpOperationStore(now func() time.Time) {
 	w.Flush()
 }
 
+type storeRecord struct {
+	Block int
+	OpKey operationKey
+	Ops   []*contract.TimelockCallScheduled
+}
+
 // writeOperationStore writes the operations to the writer.
 func writeOperationStore(
 	w io.Writer,
@@ -180,8 +186,24 @@ func writeOperationStore(
 		logger.Fatal().Msgf("error writing to buffer: %s", err.Error())
 	}
 
-	for _, record := range store {
-		op = record[0]
+	// order the store records by block number
+	storeRecords := make([]storeRecord, 0)
+	for opID, ops := range store {
+		if len(ops) <= 0 {
+			continue
+		}
+		storeRecords = append(storeRecords, storeRecord{
+			Block: int(ops[0].Raw.BlockNumber),
+			OpKey: opID,
+			Ops:   ops,
+		})
+	}
+	sort.Slice(storeRecords, func(i, j int) bool {
+		return storeRecords[i].Block < storeRecords[j].Block
+	})
+
+	for _, record := range storeRecords {
+		op = record.Ops[0]
 
 		if int(op.Raw.BlockNumber) == earliest {
 			logLine := fmt.Sprintf("earliest unexecuted CallSchedule. Use this block number when "+


### PR DESCRIPTION
There's a test flake in `scheduler_test` because the test asserts the contents of the file based on an assumed order that the store is dumped to the file.  But this ordering is not guaranteed as the `writeOperationStore` is ranging over a map.  This PR first sorts the store's contents by block number before writing them to the waiting file.