### PR TITLE
ci: use the v1.62.0 linter and fix new issues

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Linting Go
         uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
         with:
-          golangci-lint-version: v1.57.2
+          golangci-lint-version: v1.62.0
 
   ci-lint-misc:
     name: Lint Misc

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Linting Go
         uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
         with:
-          golangci-lint-version: v1.57.2
+          golangci-lint-version: v1.62.0
 
   ci-lint-misc:
     name: Lint Misc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@ run:
   timeout: 10m
   tests: false
   modules-download-mode: readonly
-output:
-  format: github-actions
 linters:
   disable-all: true
   enable:
@@ -12,13 +10,13 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - gochecknoinits
     - godot
     - gofmt
@@ -45,11 +43,6 @@ linters:
     - unconvert
     - unparam
     - whitespace
-  issues:
-    max-issues-per-linter: 0
-    max-same-issues: 0
-  severity:
-    default-severity: error
 issues:
   exclude-dirs:
   - pkg/contracts

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golang 1.22.9
-golangci-lint 1.57.2
+golangci-lint 1.62.0

--- a/pkg/timelock/scheduler.go
+++ b/pkg/timelock/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -159,11 +160,11 @@ func (tw *Worker) dumpOperationStore(now func() time.Time) {
 	tw.logger.Info().Msgf("generating logs with pending operations in %s", logPath+logFile)
 
 	// Get the earliest block from all the operations stored by sorting them.
-	blocks := make([]int, 0)
+	blocks := make([]uint64, 0)
 	for _, op := range tw.store {
-		blocks = append(blocks, int(op[0].Raw.BlockNumber))
+		blocks = append(blocks, op[0].Raw.BlockNumber)
 	}
-	sort.Ints(blocks)
+	slices.Sort(blocks)
 
 	w := bufio.NewWriter(f)
 
@@ -173,7 +174,7 @@ func (tw *Worker) dumpOperationStore(now func() time.Time) {
 }
 
 type storeRecord struct {
-	Block int
+	Block uint64
 	OpKey operationKey
 	Ops   []*contract.TimelockCallScheduled
 }
@@ -183,7 +184,7 @@ func writeOperationStore(
 	w io.Writer,
 	logger *zerolog.Logger,
 	store map[operationKey][]*contract.TimelockCallScheduled,
-	earliest int,
+	earliest uint64,
 	now func() time.Time,
 ) {
 	var (
@@ -204,7 +205,7 @@ func writeOperationStore(
 			continue
 		}
 		storeRecords = append(storeRecords, storeRecord{
-			Block: int(ops[0].Raw.BlockNumber),
+			Block: ops[0].Raw.BlockNumber,
 			OpKey: opID,
 			Ops:   ops,
 		})
@@ -216,7 +217,7 @@ func writeOperationStore(
 	for _, record := range storeRecords {
 		op = record.Ops[0]
 
-		if int(op.Raw.BlockNumber) == earliest {
+		if op.Raw.BlockNumber == earliest {
 			logLine := fmt.Sprintf("earliest unexecuted CallSchedule. Use this block number when "+
 				"spinning up the service again, with the environment variable or in timelock.env as FROM_BLOCK=%v, "+
 				"or using the flag --from-block=%v", op.Raw.BlockNumber, op.Raw.BlockNumber)

--- a/tests/integration/suite.go
+++ b/tests/integration/suite.go
@@ -48,7 +48,7 @@ func (s *integrationTestSuite) Run(name string, subtestFunc func(t *testing.T)) 
 
 func (s *integrationTestSuite) KeyedTransactor(privateKey *ecdsa.PrivateKey, chainID *big.Int) *bind.TransactOpts {
 	if chainID == nil {
-		chainID = big.NewInt(int64(s.GethContainer.ChainID))
+		chainID = new(big.Int).SetUint64(s.GethContainer.ChainID)
 	}
 
 	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)


### PR DESCRIPTION
Updates golangci-lint to v1.62.0.

The update raised issues with `gosec` around integer overflows, which have been fixed.