### PR TITLE
fix: don't panic when processing unordered operations in scheduler

### DIFF
--- a/pkg/timelock/scheduler.go
+++ b/pkg/timelock/scheduler.go
@@ -88,7 +88,7 @@ func (tw *scheduler) runScheduler(ctx context.Context) <-chan struct{} {
 
 			case op := <-tw.add:
 				tw.mu.Lock()
-				if len(tw.store[op.Id]) <= int(op.Index.Int64()) {
+				for len(tw.store[op.Id]) <= int(op.Index.Int64()) {
 					tw.store[op.Id] = append(tw.store[op.Id], op)
 				}
 				tw.store[op.Id][op.Index.Int64()] = op


### PR DESCRIPTION
When the scheduler processes multiple operations, it stores then in a slice according to their `Index` field:
```go
store[op.Id][op.Index] = op
```

To ensure the slice has the capacity to store the item, there's an allocation block, right before:
```go
if len(store[op.Id]) <= op.Index {
    store[op.Id] = append(store[op.Id], op)
}
```

However, the code above panics with "index out of range" if the delta between the slice length and the operation index is greater than 1 -- for instance, if the slice is empty and the first operation has index 2. To fix it, we must perform the `append` multiple times:
```go
for len(store[op.Id]) <= op.Index {
    store[op.Id] = append(store[op.Id], op)
}
```

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1528