### PR TITLE
fix: add 30s timeout to context used to execute operations onchain

### DIFF
--- a/pkg/timelock/operations.go
+++ b/pkg/timelock/operations.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,6 +21,9 @@ import (
 // - The operation is ready to be executed
 // Otherwise the operation will throw an info log and wait for a future tick.
 func (tw *Worker) execute(ctx context.Context, op []*contracts.RBACTimelockCallScheduled) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	if isReady(ctx, tw.contract, op[0].Id) {
 		tw.logger.Debugf("execute operation %x", op[0].Id)
 


### PR DESCRIPTION
Previously, when executing an operation, the timelock-worker called `bind.WaitMinted` with a context without an associated timeout. This meant that when there was a problem with the RPC or the network itself, the executer goroutine would get stuck waiting indefinitely for the call to return. And because all operations are called sequentially, the timelock effectively stopped working.

With the added timeout, the context aborts the network call and the operation fails. The internal logic of the scheduler will take care of retrying a few minutes later.