### PR TITLE
fix: don't specify go's patch version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/timelock-worker
 
-go 1.22.5
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0


### PR DESCRIPTION
Don't specify go's patch version in go.mod, else the docker build breaks with

```
go: go.mod requires go >= 1.22.5 (running go 1.22.3; GOTOOLCHAIN=local)
```