### PR TITLE
fix: load log config from env and remove it from Dockerfile args

### DIFF
--- a/builds/Dockerfile
+++ b/builds/Dockerfile
@@ -1,5 +1,5 @@
 # Builder image
-FROM quay.io/centos/centos:stream8 as builder
+FROM quay.io/centos/centos:stream8 AS builder
 
 USER root
 
@@ -26,4 +26,4 @@ COPY --from=builder /build/timelock-worker /app/
 WORKDIR /app
 
 ENTRYPOINT ["./timelock-worker"]
-CMD ["start", "--log-level", "${LOGLEVEL:-info}"]
+CMD ["start"]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -43,9 +44,15 @@ func configureRootCmd() error {
 	if err := viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level")); err != nil {
 		return err
 	}
+	if err := viper.BindEnv("log-level", "LOGLEVEL"); err != nil {
+		return err
+	}
 
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "human", "set logging output (human, json)")
 	if err := viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output")); err != nil {
+		return err
+	}
+	if err := viper.BindEnv("output", "OUTPUT"); err != nil {
 		return err
 	}
 
@@ -56,7 +63,7 @@ func initConfig() {
 	var err error
 	logs, err = logger.NewLogger(viper.GetString("log-level"), viper.GetString("output"))
 	if err != nil {
-		panic("unable to create logger")
+		log.Fatalf("unable to create logger: %s", err)
 	}
 
 	logs.Debug("initialized Logger")


### PR DESCRIPTION
This PR adds two fixes to the logging configuration to address an issue that was causingthe timelock-worker pods to crash:

1. load the log level and output config values from environment variables (LOGLEVEL and OUTPUT, respectively)
2. don't specify the log level as a command line parameter in the Dockefile (as it was trying to use a shell expansion which does not work from a Dockerfile)
