### PR TITLE
fix: start cmd validation on node URL for solana and improvements to log messages

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -106,7 +106,7 @@ func startTimelock(cmd *cobra.Command) {
 		}
 	} else if chainFamily == chain_selectors.FamilyEVM {
 		if !common.IsHexAddress(timelockAddress) {
-			slog.Fatalf("value of private-key is invalid for evm: %s", err.Error())
+			slog.Fatalf("value of private-key is invalid for evm")
 		}
 	}
 

--- a/pkg/timelock/worker_evm.go
+++ b/pkg/timelock/worker_evm.go
@@ -45,7 +45,7 @@ type WorkerEVM struct {
 
 var httpSchemes = []string{"http", "https"}
 
-var validNodeUrlSchemes = []string{"http", "https", "ws", "wss"}
+var validNodeUrlSchemesEVM = []string{"http", "https", "ws", "wss"}
 
 // NewTimelockWorkerEVM initializes and returns a timelockWorker.
 // It's a singleton, so further executions will retrieve the same timelockWorker.
@@ -59,8 +59,8 @@ func NewTimelockWorkerEVM(
 		return nil, err
 	}
 
-	if !slices.Contains(validNodeUrlSchemes, u.Scheme) {
-		return nil, fmt.Errorf("invalid node URL: %s (accepted schemes are: %v)", nodeURL, validNodeUrlSchemes)
+	if !slices.Contains(validNodeUrlSchemesEVM, u.Scheme) {
+		return nil, fmt.Errorf("invalid node URL: %s (accepted schemes are: %v)", nodeURL, validNodeUrlSchemesEVM)
 	}
 
 	if !common.IsHexAddress(timelockAddress) {

--- a/pkg/timelock/worker_solana.go
+++ b/pkg/timelock/worker_solana.go
@@ -20,6 +20,8 @@ import (
 	"github.com/smartcontractkit/timelock-worker/pkg/isclosed"
 )
 
+var validNodeUrlSchemesSolana = []string{"http", "https"}
+
 // WorkerSolana represents a solana worker instance. It fetches periodically the latest signatures
 // and transactions from the Solana RPC node and dispatches them to the scheduler.
 type WorkerSolana struct {
@@ -58,8 +60,8 @@ func NewTimelockWorkerSolana(
 		return nil, err
 	}
 
-	if !slices.Contains(validNodeUrlSchemes, u.Scheme) {
-		return nil, fmt.Errorf("invalid node URL: %s (accepted schemes are: %v)", nodeURL, validNodeUrlSchemes)
+	if !slices.Contains(validNodeUrlSchemesSolana, u.Scheme) {
+		return nil, fmt.Errorf("invalid node URL: %s (accepted schemes are: %v)", nodeURL, validNodeUrlSchemesEVM)
 	}
 
 	timelockPubKey, instanceSeed, err := mcmssolanasdk.ParseContractAddress(timelockAddress)
@@ -178,6 +180,7 @@ func (w *WorkerSolana) pollSignatures(ctx context.Context, sigCh chan<- solana.S
 			w.logger.Info("pollSignatures context cancelled")
 			return
 		case <-ticker.C:
+			w.logger.Infow("polling signatures timelock solana", "timelockProgramKey", w.timelockProgramKey, "lastSignature", w.lastSignature)
 			var until solana.Signature
 			if w.lastSignature != nil {
 				until = *w.lastSignature
@@ -197,9 +200,10 @@ func (w *WorkerSolana) pollSignatures(ctx context.Context, sigCh chan<- solana.S
 				continue
 			}
 			if len(sigs) == 0 {
+				w.logger.Info("no new signatures found, poll again in the next cycle")
 				continue
 			}
-
+			w.logger.Infow("found new signatures", "numSignatures", len(sigs))
 			slices.Reverse(sigs)
 			for _, info := range sigs {
 				select {
@@ -363,7 +367,7 @@ func (w *WorkerSolana) handleTx(ctx context.Context, tx *rpc.TransactionWithMeta
 // handleEventCancelled checks if the operation is cancelled and deletes it from the scheduler if it is.
 func (w *WorkerSolana) handleEventCancelled(_ context.Context, event SolanaTimelockCallCancelledEvent) {
 	w.logger.With(operationID, fmt.Sprintf("%x", event.ID)).
-		Infow("event received, cancelling operation", "event type", eventCancelled)
+		Infow("event Cancelled received, cancelling operation", "event type", eventCancelled)
 
 	w.scheduler.delFromScheduler(event.ID)
 }
@@ -379,7 +383,7 @@ func (w *WorkerSolana) handleEventExecuted(ctx context.Context, event SolanaTime
 		return fmt.Errorf("timelock.isOperationDone call failed (operation id: %x): %w", event.ID, err)
 	}
 	if isDone {
-		logger.Infow("event received, deleting operation from scheduler", "event type ", eventCallExecuted)
+		logger.Infow("event CallExecuted received, deleting operation from scheduler", "event type ", eventCallExecuted)
 
 		w.scheduler.delFromScheduler(event.ID)
 	} else {

--- a/tests/integration/solana/worker_test.go
+++ b/tests/integration/solana/worker_test.go
@@ -73,7 +73,7 @@ func (s *solanaIntegrationTestSuite) TestTimelockWorkerListen() {
 
 		s.EventuallyWithT(func(collect *assert.CollectT) {
 			assert.GreaterOrEqual(collect, logs.FilterMessageSnippet("found event cancelled").Len(), 1)
-			assert.GreaterOrEqual(collect, logs.FilterMessageSnippet("event received, cancelling operation").Len(), 1)
+			assert.GreaterOrEqual(collect, logs.FilterMessageSnippet("event Cancelled received, cancelling operation").Len(), 1)
 			assert.GreaterOrEqual(collect, logs.FilterMessageSnippet("nop.delFromScheduler").Len(), 1)
 		}, 10*time.Second, 200*time.Millisecond, logMessages(logs))
 	}


### PR DESCRIPTION
Small fixes on:

- Log messages for easier debugging 
- panic happening on the start cmd
- updates to tests based on new log messages