### PR TITLE
fix: docker install ca-certificates

### DIFF
--- a/builds/Dockerfile
+++ b/builds/Dockerfile
@@ -16,7 +16,9 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags='-w -s -extldflags "-static"' -o timelock-worker .
 
 # Final image: minimal scratch with only the binary
-FROM scratch
+FROM alpine:latest
+# Install CA certs
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /build/timelock-worker /timelock-worker
 ENTRYPOINT ["/timelock-worker"]
 CMD ["start"]


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the `timelock-worker` to use a more robust base image and ensure proper functionality in secure environments.

### Dockerfile improvements:

* Updated the base image from `scratch` to `alpine:latest` to provide a minimal but functional environment.
* Added a step to install CA certificates using `apk add --no-cache ca-certificates`, ensuring the application can handle HTTPS connections.