### PR TITLE
chore: update codeowners to op-tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @smartcontractkit/devex-tooling
+* @smartcontractkit/op-tooling


### PR DESCRIPTION
This updates the CODEOWNERS file to transfer ownership to the `op-tooling` team.